### PR TITLE
Update README to link to development repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Whole Cell Model - *Escherichia coli*
 
-**Notice:** This repository contains a **release snapshot** of the [Covert Lab's](https://www.covert.stanford.edu/) Whole Cell Model for [*Escherichia coli*](https://en.wikipedia.org/wiki/Escherichia_coli). In contrast, our working repository is under continuous development so please contact us before embarking on any changes that you want to contribute. We do **not** plan to merge Pull Requests into this repository except documentation and installation fixes.
+**Notice:** This repository contains **previous release snapshots** of the [Covert Lab's](https://www.covert.stanford.edu/) Whole Cell Model for [*Escherichia coli*](https://en.wikipedia.org/wiki/Escherichia_coli). For the most recent versions of the *E. coli* whole-cell model that are undergoing active development, please visit the [wcEcoli](https://github.com/CovertLab/wcEcoli) and the [vivarium-ecoli](https://github.com/CovertLab/vivarium-ecoli) repositories. This repository should only be used for the purpose of replicating model outputs generated for previous publications listed below. We do **not** plan to merge Pull Requests into this repository except documentation and installation fixes.
 
 You can reach us at [AllenCenterCovertLab](mailto:allencentercovertlab@gmail.com).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Notice:** This repository contains **previous release snapshots** of the [Covert Lab's](https://www.covert.stanford.edu/) Whole Cell Model for [*Escherichia coli*](https://en.wikipedia.org/wiki/Escherichia_coli). For the most recent versions of the *E. coli* whole-cell model that are undergoing active development, please visit the [wcEcoli](https://github.com/CovertLab/wcEcoli) and the [vivarium-ecoli](https://github.com/CovertLab/vivarium-ecoli) repositories. This repository should only be used for the purpose of replicating model outputs generated for previous publications listed below. We do **not** plan to merge Pull Requests into this repository except documentation and installation fixes.
 
-You can reach us at [AllenCenterCovertLab](mailto:allencentercovertlab@gmail.com).
+You can reach us at [WholeCellTeam](mailto:wholecellteam@lists.stanford.edu).
 
 This repository contains code for the following publications:
 - [Simultaneous cross-evaluation of heterogeneous _E. coli_ datasets via mechanistic simulation](https://science.sciencemag.org/content/369/6502/eaav3751.full) published in _Science_, 24 July 2020. ([Release](https://github.com/CovertLab/WholeCellEcoliRelease/releases/tag/v1.0))


### PR DESCRIPTION
This PR updates the main README of the repository to contain links to `wcEcoli` and `vivarium-ecoli`, both of which had recently been transitioned into public repositories.